### PR TITLE
✨ Annotate commands with version metadata

### DIFF
--- a/cmd/clip/clip.go
+++ b/cmd/clip/clip.go
@@ -5,7 +5,8 @@ import (
 )
 
 var ClipCmd = &cobra.Command{
-	Use:   "clip",
-	Short: "Interact with the native clipboard",
-	Long:  "Reach the browser clipboard from the terminal over the workspace IPC socket.",
+	Use:         "clip",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Interact with the native clipboard",
+	Long:        "Reach the browser clipboard from the terminal over the workspace IPC socket.",
 }

--- a/cmd/clip/paste.go
+++ b/cmd/clip/paste.go
@@ -6,9 +6,10 @@ import (
 )
 
 var pasteCmd = &cobra.Command{
-	Use:   "paste",
-	Short: "Paste clipboard content",
-	Long:  "Read the browser clipboard over the workspace IPC socket and write it to stdout — redirect it to a file or pipe it onward. Pairs with the pbcopy/xclip/xsel shims for terminal clipboard access.",
+	Use:         "paste",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Paste clipboard content",
+	Long:        "Read the browser clipboard over the workspace IPC socket and write it to stdout — redirect it to a file or pipe it onward. Pairs with the pbcopy/xclip/xsel shims for terminal clipboard access.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return clipboard.Paste(cmd.OutOrStdout())
 	},

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kloudkit/ws-cli/cmd"
 	"github.com/kloudkit/ws-cli/internals/docs"
+	"gopkg.in/yaml.v3"
 	"gotest.tools/v3/assert"
 )
 
@@ -18,6 +19,25 @@ func TestCommandsManifestMatchesCommittedFile(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, string(got), string(want))
+}
+
+func TestEveryCommandCarriesVersion(t *testing.T) {
+	out, err := docs.Serialize(cmd.RootCmd())
+	assert.NilError(t, err)
+
+	var root docs.Command
+	assert.NilError(t, yaml.Unmarshal(out, &root))
+
+	var check func(docs.Command)
+	check = func(c docs.Command) {
+		for _, child := range c.Commands {
+			assert.Assert(t, child.Since != "" || child.Deprecated != "",
+				"command %q must carry a since or deprecated annotation", child.Name)
+			check(child)
+		}
+	}
+
+	check(root)
 }
 
 func TestSerializeIsDeterministic(t *testing.T) {

--- a/cmd/editor/diagnostics.go
+++ b/cmd/editor/diagnostics.go
@@ -11,9 +11,10 @@ import (
 )
 
 var diagnosticsCmd = &cobra.Command{
-	Use:   "diagnostics",
-	Short: "Show language diagnostics for the workspace (or a single file)",
-	Long:  "Pull language-server diagnostics (errors, warnings) from the editor over the IPC socket, across the whole workspace or a single file with --uri. Styled table by default, --raw for the JSON.",
+	Use:         "diagnostics",
+	Annotations: map[string]string{"since": "next"},
+	Short:       "Show language diagnostics for the workspace (or a single file)",
+	Long:        "Pull language-server diagnostics (errors, warnings) from the editor over the IPC socket, across the whole workspace or a single file with --uri. Styled table by default, --raw for the JSON.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		uri, _ := cmd.Flags().GetString("uri")
 

--- a/cmd/editor/editor.go
+++ b/cmd/editor/editor.go
@@ -16,9 +16,10 @@ var errNoEditorOverSSH = errors.New(
 )
 
 var EditorCmd = &cobra.Command{
-	Use:   "editor",
-	Short: "Inspect and drive the active editor session",
-	Long:  "Query and control the running VS Code / code-server window over the workspace IPC socket — list open tabs, read diagnostics and the current selection, or open a file. Blocked over SSH, where there is no browser editor to reach.",
+	Use:         "editor",
+	Annotations: map[string]string{"since": "next"},
+	Short:       "Inspect and drive the active editor session",
+	Long:        "Query and control the running VS Code / code-server window over the workspace IPC socket — list open tabs, read diagnostics and the current selection, or open a file. Blocked over SSH, where there is no browser editor to reach.",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if env.IsSSHSession() {
 			return errNoEditorOverSSH

--- a/cmd/editor/list.go
+++ b/cmd/editor/list.go
@@ -11,9 +11,10 @@ import (
 )
 
 var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List the currently open editor tabs",
-	Long:  "List the editor's open tabs over the IPC socket, with each tab's path, language, and active or dirty state.",
+	Use:         "list",
+	Annotations: map[string]string{"since": "next"},
+	Short:       "List the currently open editor tabs",
+	Long:        "List the editor's open tabs over the IPC socket, with each tab's path, language, and active or dirty state.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		body, err := editoripc.FetchEditors()
 		if err != nil {

--- a/cmd/editor/open.go
+++ b/cmd/editor/open.go
@@ -10,10 +10,11 @@ import (
 )
 
 var openCmd = &cobra.Command{
-	Use:   "open <file>",
-	Short: "Open a file in the editor",
-	Long:  "Open a file in the running editor window over the workspace IPC socket — a tab in the current window by default, a separate one with --new-window, jumping to a range with --selection. Fails fast over SSH, where there is no browser editor to open into.",
-	Args:  cobra.ExactArgs(1),
+	Use:         "open <file>",
+	Annotations: map[string]string{"since": "next"},
+	Short:       "Open a file in the editor",
+	Long:        "Open a file in the running editor window over the workspace IPC socket — a tab in the current window by default, a separate one with --new-window, jumping to a range with --selection. Fails fast over SSH, where there is no browser editor to open into.",
+	Args:        cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		newWindow, _ := cmd.Flags().GetBool("new-window")
 		preview, _ := cmd.Flags().GetBool("preview")

--- a/cmd/editor/selection.go
+++ b/cmd/editor/selection.go
@@ -11,9 +11,10 @@ import (
 )
 
 var selectionCmd = &cobra.Command{
-	Use:   "selection",
-	Short: "Show the active editor's current selection",
-	Long:  "Report the active editor's current selection — file, range, and selected text — over the IPC socket. Empty when nothing is selected.",
+	Use:         "selection",
+	Annotations: map[string]string{"since": "next"},
+	Short:       "Show the active editor's current selection",
+	Long:        "Report the active editor's current selection — file, range, and selected text — over the IPC socket. Empty when nothing is selected.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		body, err := editoripc.FetchSelection()
 		if err != nil {

--- a/cmd/feature/feature.go
+++ b/cmd/feature/feature.go
@@ -7,9 +7,10 @@ import (
 )
 
 var FeatureCmd = &cobra.Command{
-	Use:   "feature",
-	Short: "Install additional pre-configured features",
-	Long:  "Install and inspect optional workspace features — Ansible playbooks that add tools on top of the base image. Ships a curated set; --root points at your own under ~/.ws/features.d.",
+	Use:         "feature",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Install additional pre-configured features",
+	Long:        "Install and inspect optional workspace features — Ansible playbooks that add tools on top of the base image. Ships a curated set; --root points at your own under ~/.ws/features.d.",
 }
 
 func featureDirs(cmd *cobra.Command) []string {

--- a/cmd/feature/info.go
+++ b/cmd/feature/info.go
@@ -9,10 +9,11 @@ import (
 )
 
 var infoCmd = &cobra.Command{
-	Use:   "info <name>",
-	Short: "Show detailed information about a feature",
-	Long:  "Show a feature's description and the variables it accepts, so you know what --opt values install will take.",
-	Args:  cobra.ExactArgs(1),
+	Use:         "info <name>",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Show detailed information about a feature",
+	Long:        "Show a feature's description and the variables it accepts, so you know what --opt values install will take.",
+	Args:        cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		featureName := args[0]
 

--- a/cmd/feature/install.go
+++ b/cmd/feature/install.go
@@ -23,10 +23,11 @@ var skippableSections = []struct {
 }
 
 var installCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install additional pre-configured features",
-	Long:  "Run a feature's playbook to install it. Pass variables with --opt KEY=VAL, and skip parts you do not want with --skip-extensions, --skip-completion, or --skip-repository.",
-	Args:  cobra.ExactArgs(1),
+	Use:         "install",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Install additional pre-configured features",
+	Long:        "Run a feature's playbook to install it. Pass variables with --opt KEY=VAL, and skip parts you do not want with --skip-extensions, --skip-completion, or --skip-repository.",
+	Args:        cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		featureName := args[0]
 

--- a/cmd/feature/list.go
+++ b/cmd/feature/list.go
@@ -9,10 +9,11 @@ import (
 )
 
 var listCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List available features that can be installed",
-	Long:    "List the features you can install, marking where each comes from — the shipped set, a workspace override, or your own ~/.ws/features.d.",
-	Aliases: []string{"ls"},
+	Use:         "list",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "List available features that can be installed",
+	Long:        "List the features you can install, marking where each comes from — the shipped set, a workspace override, or your own ~/.ws/features.d.",
+	Aliases:     []string{"ls"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		result, err := features.ListFeatures(featureDirs(cmd))
 		if err != nil {

--- a/cmd/feature/new.go
+++ b/cmd/feature/new.go
@@ -18,8 +18,9 @@ const scaffoldTemplate = `---
 `
 
 var newCmd = &cobra.Command{
-	Use:   "new [name]",
-	Short: "Print boilerplate for a custom feature playbook",
+	Use:         "new [name]",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Print boilerplate for a custom feature playbook",
 	Long: `Print a starter feature playbook to stdout.
 
 Redirect it into ~/.ws/features.d/<name>.yaml, then extend it and install

--- a/cmd/feature/store.go
+++ b/cmd/feature/store.go
@@ -10,9 +10,10 @@ import (
 )
 
 var storeCmd = &cobra.Command{
-	Use:   "store",
-	Short: "List packages available in the feature store",
-	Long:  "List the artifacts published to the feature store (WS_FEATURES_STORE_URL) — the offline mirror features install from when the network is locked down.",
+	Use:         "store",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "List packages available in the feature store",
+	Long:        "List the artifacts published to the feature store (WS_FEATURES_STORE_URL) — the offline mirror features install from when the network is locked down.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		storeURL, _ := config.Resolve("features", "store_url")
 		if storeURL == "" {

--- a/cmd/info/env.go
+++ b/cmd/info/env.go
@@ -31,9 +31,10 @@ func showEnvironment(writer io.Writer) {
 }
 
 var envCmd = &cobra.Command{
-	Use:   "env",
-	Short: "Display effective workspace environment variables",
-	Long:  "Print every WS_* variable in effect, sorted — the resolved environment the workspace booted with.",
+	Use:         "env",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display effective workspace environment variables",
+	Long:        "Print every WS_* variable in effect, sorted — the resolved environment the workspace booted with.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		showEnvironment(cmd.OutOrStdout())
 		return nil

--- a/cmd/info/extensions.go
+++ b/cmd/info/extensions.go
@@ -10,9 +10,10 @@ import (
 )
 
 var extensionsCmd = &cobra.Command{
-	Use:   "extensions",
-	Short: "Display installed extensions",
-	Long:  "List the installed VS Code extensions with their versions.",
+	Use:         "extensions",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display installed extensions",
+	Long:        "List the installed VS Code extensions with their versions.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		extensions, _ := config.GetExtensions()
 

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -34,15 +34,17 @@ func showVersion(writer io.Writer) {
 }
 
 var InfoCmd = &cobra.Command{
-	Use:   "info",
-	Short: "Display workspace information",
-	Long:  "Report facts about the running workspace — version, effective environment, installed extensions, live resource metrics, and uptime.",
+	Use:         "info",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display workspace information",
+	Long:        "Report facts about the running workspace — version, effective environment, installed extensions, live resource metrics, and uptime.",
 }
 
 var showVersionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display installed workspace version",
-	Long:  "Print the workspace version. --all expands to the full table — workspace, ws-cli, and VS Code.",
+	Use:         "version",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display installed workspace version",
+	Long:        "Print the workspace version. --all expands to the full table — workspace, ws-cli, and VS Code.",
 	Run: func(cmd *cobra.Command, args []string) {
 		if all, _ := cmd.Flags().GetBool("all"); all {
 			showVersion(cmd.OutOrStdout())

--- a/cmd/info/metrics.go
+++ b/cmd/info/metrics.go
@@ -10,9 +10,10 @@ import (
 )
 
 var metricsCmd = &cobra.Command{
-	Use:   "metrics",
-	Short: "Display workspace metrics",
-	Long:  "Show live resource usage — CPU, memory, disk, and file descriptors, plus GPU with --gpu.",
+	Use:         "metrics",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display workspace metrics",
+	Long:        "Show live resource usage — CPU, memory, disk, and file descriptors, plus GPU with --gpu.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		includeGPU, _ := cmd.Flags().GetBool("gpu")
 

--- a/cmd/info/uptime.go
+++ b/cmd/info/uptime.go
@@ -10,9 +10,10 @@ import (
 )
 
 var uptimeCmd = &cobra.Command{
-	Use:   "uptime",
-	Short: "Display the workspace uptime",
-	Long:  "Show when the workspace session started and how long it has been running.",
+	Use:         "uptime",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display the workspace uptime",
+	Long:        "Show when the workspace session started and how long it has been running.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		started, running, err := config.GetSessionInfo()
 

--- a/cmd/log/log.go
+++ b/cmd/log/log.go
@@ -8,9 +8,10 @@ import (
 )
 
 var LogCmd = &cobra.Command{
-	Use:   "log",
-	Short: "Log messages",
-	Long:  "Emit styled, level-tagged log lines — the same formatting the startup scripts use. --pipe runs each line of piped input through the logger.",
+	Use:         "log",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Log messages",
+	Long:        "Emit styled, level-tagged log lines — the same formatting the startup scripts use. --pipe runs each line of piped input through the logger.",
 }
 
 var debugCmd = createCommand("debug", "debugging")
@@ -18,10 +19,11 @@ var errorCmd = createCommand("error", "error")
 var infoCmd = createCommand("info", "information")
 var warnCmd = createCommand("warn", "warning")
 var stampCmd = &cobra.Command{
-	Use:   "stamp",
-	Short: "Log the current timestamp",
-	Long:  "Print just the current timestamp in the workspace log style — handy for marking phases in a startup log.",
-	Args:  cobra.NoArgs,
+	Use:         "stamp",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Log the current timestamp",
+	Long:        "Print just the current timestamp in the workspace log style — handy for marking phases in a startup log.",
+	Args:        cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		withPipe, _ := cmd.Flags().GetBool("pipe")
 
@@ -36,11 +38,12 @@ var stampCmd = &cobra.Command{
 
 func createCommand(short, long string) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("%s message", short),
-		Short: fmt.Sprintf("Log %s messages", long),
-		Long:  fmt.Sprintf("Emit a log line at %s level in the workspace style — the same formatting the startup scripts use. --indent nests it under a preceding line, --stamp prefixes a timestamp.", short),
-		Args:  validate,
-		RunE:  execute(short),
+		Use:         fmt.Sprintf("%s message", short),
+		Annotations: map[string]string{"since": "0.2.0"},
+		Short:       fmt.Sprintf("Log %s messages", long),
+		Long:        fmt.Sprintf("Emit a log line at %s level in the workspace style — the same formatting the startup scripts use. --indent nests it under a preceding line, --stamp prefixes a timestamp.", short),
+		Args:        validate,
+		RunE:        execute(short),
 	}
 
 	cmd.Flags().IntP("indent", "i", 0, "Desired prefixed indentation")

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -15,11 +15,12 @@ var validLogLevels = []string{"debug", "info", "warn", "error"}
 var validLogTargets = []string{"main", "metrics", "docker", "auth_proxy", "cloudflared"}
 
 var LogsCmd = &cobra.Command{
-	Use:   "logs",
-	Short: "Retrieve workspace logs",
-	Long:  "Read a workspace daemon's log — the main log by default, or --target metrics|docker|auth_proxy|cloudflared. Filter by --level, limit with --tail, or stream live with --follow.",
-	Args:  cobra.NoArgs,
-	RunE:  execute,
+	Use:         "logs",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Retrieve workspace logs",
+	Long:        "Read a workspace daemon's log — the main log by default, or --target metrics|docker|auth_proxy|cloudflared. Filter by --level, limit with --tail, or stream live with --follow.",
+	Args:        cobra.NoArgs,
+	RunE:        execute,
 }
 
 func execute(cmd *cobra.Command, args []string) error {

--- a/cmd/secrets/decrypt.go
+++ b/cmd/secrets/decrypt.go
@@ -7,10 +7,11 @@ import (
 )
 
 var decryptCmd = &cobra.Command{
-	Use:   "decrypt <encrypted|->",
-	Short: "Decrypt an encrypted value",
-	Long:  "Decrypt a value produced by encrypt, under the master key. Reads from the argument or stdin (-); writes the plaintext to stdout, or a file with --output.",
-	Args:  cobra.ExactArgs(1),
+	Use:         "decrypt <encrypted|->",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Decrypt an encrypted value",
+	Long:        "Decrypt a value produced by encrypt, under the master key. Reads from the argument or stdin (-); writes the plaintext to stdout, or a file with --output.",
+	Args:        cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := getOutputConfig(cmd)
 		masterKeyFlag, _ := cmd.Flags().GetString("master")

--- a/cmd/secrets/encrypt.go
+++ b/cmd/secrets/encrypt.go
@@ -10,10 +10,11 @@ import (
 )
 
 var encryptCmd = &cobra.Command{
-	Use:   "encrypt <plaintext|->",
-	Short: "Encrypt a plaintext value",
-	Long:  "Encrypt a value under the master key. Reads the plaintext from the argument or stdin (-); writes the ciphertext to stdout, or a file with --output.",
-	Args:  cobra.ExactArgs(1),
+	Use:         "encrypt <plaintext|->",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Encrypt a plaintext value",
+	Long:        "Encrypt a value under the master key. Reads the plaintext from the argument or stdin (-); writes the ciphertext to stdout, or a file with --output.",
+	Args:        cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := getOutputConfig(cmd)
 		masterKeyFlag, _ := cmd.Flags().GetString("master")

--- a/cmd/secrets/generate.go
+++ b/cmd/secrets/generate.go
@@ -3,9 +3,10 @@ package secrets
 import "github.com/spf13/cobra"
 
 var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generate master keys or login password hashes",
-	Long:  "Generate the credentials the workspace needs — a master key for secrets, or a login password hash for the server.",
+	Use:         "generate",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Generate master keys or login password hashes",
+	Long:        "Generate the credentials the workspace needs — a master key for secrets, or a login password hash for the server.",
 }
 
 func init() {

--- a/cmd/secrets/login.go
+++ b/cmd/secrets/login.go
@@ -11,10 +11,11 @@ import (
 )
 
 var loginCmd = &cobra.Command{
-	Use:   "login",
-	Short: "Generate a workspace password hash for authentication",
-	Long:  "Prompt for a password and print its hash for the workspace server login (WS_AUTH_PASSWORD_HASHED). Store the hash, never the password.",
-	Args:  cobra.NoArgs,
+	Use:         "login",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Generate a workspace password hash for authentication",
+	Long:        "Prompt for a password and print its hash for the workspace server login (WS_AUTH_PASSWORD_HASHED). Store the hash, never the password.",
+	Args:        cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := getOutputConfig(cmd)
 		return generateLoginHash(cmd, cfg)

--- a/cmd/secrets/master.go
+++ b/cmd/secrets/master.go
@@ -12,10 +12,11 @@ import (
 )
 
 var masterCmd = &cobra.Command{
-	Use:   "master",
-	Short: "Generate a cryptographically secure master key",
-	Long:  "Generate a random master key, printed base64-encoded — the key encrypt, decrypt, and the seed engine use. --length sets the byte size (default 32).",
-	Args:  cobra.NoArgs,
+	Use:         "master",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Generate a cryptographically secure master key",
+	Long:        "Generate a random master key, printed base64-encoded — the key encrypt, decrypt, and the seed engine use. --length sets the byte size (default 32).",
+	Args:        cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := getOutputConfig(cmd)
 		keyLength, _ := cmd.Flags().GetInt("length")

--- a/cmd/secrets/secrets.go
+++ b/cmd/secrets/secrets.go
@@ -5,9 +5,10 @@ import (
 )
 
 var SecretsCmd = &cobra.Command{
-	Use:   "secrets",
-	Short: "Manage encryption and decryption of secrets",
-	Long:  "Encrypt and decrypt values under a master key, and generate the keys themselves. Encrypted values are what the seed engine's secrets: map stores and decrypts at boot.",
+	Use:         "secrets",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Manage encryption and decryption of secrets",
+	Long:        "Encrypt and decrypt values under a master key, and generate the keys themselves. Encrypted values are what the seed engine's secrets: map stores and decrypts at boot.",
 }
 
 func init() {

--- a/cmd/seed/apply.go
+++ b/cmd/seed/apply.go
@@ -14,6 +14,7 @@ var applyCmd = &cobra.Command{
 	Short:        "Project seed content onto the filesystem",
 	Long:         "Apply the seed source to the filesystem — mirror bare files and run the .seed.yaml operations. Writes only where the destination is missing unless --force; pass destinations to limit the run to those paths.",
 	SilenceUsage: true,
+	Annotations:  map[string]string{"since": "next"},
 	RunE:         runApply,
 }
 

--- a/cmd/seed/ls.go
+++ b/cmd/seed/ls.go
@@ -9,10 +9,11 @@ import (
 )
 
 var lsCmd = &cobra.Command{
-	Use:   "ls",
-	Short: "List seed destinations and their behaviors",
-	Long:  "List what apply would write — each destination with its operation and whether it carries a secret or a template — without touching the filesystem.",
-	RunE:  runLs,
+	Use:         "ls",
+	Short:       "List seed destinations and their behaviors",
+	Long:        "List what apply would write — each destination with its operation and whether it carries a secret or a template — without touching the filesystem.",
+	Annotations: map[string]string{"since": "next"},
+	RunE:        runLs,
 }
 
 func runLs(cmd *cobra.Command, args []string) error {

--- a/cmd/seed/rotate.go
+++ b/cmd/seed/rotate.go
@@ -10,6 +10,7 @@ var rotateCmd = &cobra.Command{
 	Short:        "Re-encrypt managed secrets under a new master key",
 	Long:         "Re-encrypt every managed secret from the old master key (--master) to a new one (--new-master), in place. All-or-nothing: it verifies every secret decrypts before writing anything.",
 	SilenceUsage: true,
+	Annotations:  map[string]string{"since": "next"},
 	RunE:         runRotate,
 }
 

--- a/cmd/seed/seed.go
+++ b/cmd/seed/seed.go
@@ -6,9 +6,10 @@ import (
 )
 
 var SeedCmd = &cobra.Command{
-	Use:   "seed",
-	Short: "Project declarative content onto the filesystem",
-	Long:  "Copy files and apply small edits from a seed source onto the filesystem at boot. Bare files mirror verbatim; a .seed.yaml manifest overlays behavior — copy, merge, append — and decrypts secrets under the master key. Point --source at a mounted volume to seed a container from durable storage.",
+	Use:         "seed",
+	Short:       "Project declarative content onto the filesystem",
+	Long:        "Copy files and apply small edits from a seed source onto the filesystem at boot. Bare files mirror verbatim; a .seed.yaml manifest overlays behavior — copy, merge, append — and decrypts secrets under the master key. Point --source at a mounted volume to seed a container from durable storage.",
+	Annotations: map[string]string{"since": "next"},
 }
 
 func init() {

--- a/cmd/serve/current.go
+++ b/cmd/serve/current.go
@@ -10,9 +10,10 @@ import (
 )
 
 var currentCmd = &cobra.Command{
-	Use:   "current",
-	Short: "Serve current directory as a static site",
-	Long:  "Serve the current directory over HTTP as a static site — a quick way to preview built files.",
+	Use:         "current",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Serve current directory as a static site",
+	Long:        "Serve the current directory over HTTP as a static site — a quick way to preview built files.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		port, _ := cmd.Flags().GetInt("port")
 		bind, _ := cmd.Flags().GetString("bind")

--- a/cmd/serve/font.go
+++ b/cmd/serve/font.go
@@ -9,9 +9,10 @@ import (
 )
 
 var fontCmd = &cobra.Command{
-	Use:   "font",
-	Short: "Serve fonts for local download",
-	Long:  "Serve the installed fonts over HTTP so a browser can fetch them for local install.",
+	Use:         "font",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Serve fonts for local download",
+	Long:        "Serve the installed fonts over HTTP so a browser can fetch them for local install.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		port, _ := cmd.Flags().GetInt("port")
 		bind, _ := cmd.Flags().GetString("bind")

--- a/cmd/serve/metrics.go
+++ b/cmd/serve/metrics.go
@@ -11,8 +11,9 @@ import (
 )
 
 var metricsCmd = &cobra.Command{
-	Use:   "metrics",
-	Short: "Start the Prometheus metrics server",
+	Use:         "metrics",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Start the Prometheus metrics server",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		port, _ := cmd.Flags().GetInt("port")
 		collectors, _ := cmd.Flags().GetStringSlice("collectors")

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -3,9 +3,10 @@ package serve
 import "github.com/spf13/cobra"
 
 var ServeCmd = &cobra.Command{
-	Use:   "serve",
-	Short: "Serve internal assets",
-	Long:  "Run a small HTTP server for local assets — fonts or the current directory — on --port (default 38080).",
+	Use:         "serve",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Serve internal assets",
+	Long:        "Run a small HTTP server for local assets — fonts or the current directory — on --port (default 38080).",
 }
 
 func init() {

--- a/cmd/show/env.go
+++ b/cmd/show/env.go
@@ -15,10 +15,11 @@ import (
 var osExit = os.Exit
 
 var envCmd = &cobra.Command{
-	Use:   "env <KEY>",
-	Short: "Display the resolved value of a workspace environment variable",
-	Long:  "Resolve a setting by its dotted key (server.port) and print it with its source and description. --value emits just the value for scripts, --as bool|int|list validates the shape, --check tests whether it is set so a startup script can guard on it.",
-	Args:  cobra.ExactArgs(1),
+	Use:         "env <KEY>",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display the resolved value of a workspace environment variable",
+	Long:        "Resolve a setting by its dotted key (server.port) and print it with its source and description. --value emits just the value for scripts, --as bool|int|list validates the shape, --check tests whether it is set so a startup script can guard on it.",
+	Args:        cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dotted := args[0]
 

--- a/cmd/show/ip.go
+++ b/cmd/show/ip.go
@@ -7,16 +7,18 @@ import (
 )
 
 var ipCmd = &cobra.Command{
-	Use:   "ip",
-	Short: "Display IP addresses",
-	Long:  "Print the workspace's IP addresses — the internal container address or the node it runs on.",
+	Use:         "ip",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display IP addresses",
+	Long:        "Print the workspace's IP addresses — the internal container address or the node it runs on.",
 }
 
 func makeIPCmd(use, short, long, title string, getter func() (string, error)) *cobra.Command {
 	return &cobra.Command{
-		Use:   use,
-		Short: short,
-		Long:  long,
+		Use:         use,
+		Annotations: map[string]string{"since": "0.2.0"},
+		Short:       short,
+		Long:        long,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ip, err := getter()
 			if err != nil {

--- a/cmd/show/path.go
+++ b/cmd/show/path.go
@@ -8,15 +8,17 @@ import (
 )
 
 var pathCmd = &cobra.Command{
-	Use:   "path",
-	Short: "Display various paths",
-	Long:  "Print well-known workspace paths — the home root or the VS Code settings file.",
+	Use:         "path",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display various paths",
+	Long:        "Print well-known workspace paths — the home root or the VS Code settings file.",
 }
 
 var pathHomeCmd = &cobra.Command{
-	Use:   "home",
-	Short: "Display the workspace home path",
-	Long:  "Print the workspace home (server root) path.",
+	Use:         "home",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display the workspace home path",
+	Long:        "Print the workspace home (server root) path.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		homePath := config.MustResolve("server", "root")
 
@@ -33,9 +35,10 @@ var pathHomeCmd = &cobra.Command{
 }
 
 var pathVscodeCmd = &cobra.Command{
-	Use:   "vscode-settings",
-	Short: "Display the VS Code settings path",
-	Long:  "Print the path to the VS Code settings file — the user file by default, or the folder's with --workspace.",
+	Use:         "vscode-settings",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display the VS Code settings path",
+	Long:        "Print the path to the VS Code settings file — the user file by default, or the folder's with --workspace.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		useWorkspace, _ := cmd.Flags().GetBool("workspace")
 

--- a/cmd/show/show.go
+++ b/cmd/show/show.go
@@ -5,9 +5,10 @@ import (
 )
 
 var ShowCmd = &cobra.Command{
-	Use:   "show",
-	Short: "Display information about the current workspace instance",
-	Long:  "Resolve and print facts about this workspace instance — settings, IP addresses, and paths. --raw drops the styling for use in scripts.",
+	Use:         "show",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display information about the current workspace instance",
+	Long:        "Resolve and print facts about this workspace instance — settings, IP addresses, and paths. --raw drops the styling for use in scripts.",
 }
 
 func init() {

--- a/cmd/template/apply.go
+++ b/cmd/template/apply.go
@@ -10,6 +10,7 @@ import (
 
 var applyCmd = &cobra.Command{
 	Use:               "apply <template>",
+	Annotations:       map[string]string{"since": "0.2.0"},
 	Short:             "Apply a configuration template to the current project",
 	Long:              "Copy a template into the project — a shared config like ruff or markdownlint — to --path (the current directory by default). --force overwrites an existing file.",
 	Args:              cobra.ExactArgs(1),

--- a/cmd/template/list.go
+++ b/cmd/template/list.go
@@ -11,11 +11,12 @@ import (
 )
 
 var listCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List all available configuration templates",
-	Long:    "List the templates you can apply, with their source paths and whether one is already applied here.",
-	Aliases: []string{"ls"},
-	RunE:    runList,
+	Use:         "list",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "List all available configuration templates",
+	Long:        "List the templates you can apply, with their source paths and whether one is already applied here.",
+	Aliases:     []string{"ls"},
+	RunE:        runList,
 }
 
 func runList(cmd *cobra.Command, args []string) error {

--- a/cmd/template/show.go
+++ b/cmd/template/show.go
@@ -10,8 +10,9 @@ import (
 )
 
 var showCmd = &cobra.Command{
-	Use:   "show <template>",
-	Short: "Display the contents of a configuration template",
+	Use:         "show <template>",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Display the contents of a configuration template",
 	Long: fmt.Sprintf(`Display the contents of a configuration template.
 
   Available templates: %s`, strings.Join(template.GetTemplateNames(), ", ")),

--- a/cmd/template/template.go
+++ b/cmd/template/template.go
@@ -5,7 +5,8 @@ import (
 )
 
 var TemplateCmd = &cobra.Command{
-	Use:   "template",
-	Short: "Manage static configuration files",
-	Long:  "Copy shared configuration files (linters, formatters) from their global locations into a project, and inspect what they hold.",
+	Use:         "template",
+	Annotations: map[string]string{"since": "0.2.0"},
+	Short:       "Manage static configuration files",
+	Long:        "Copy shared configuration files (linters, formatters) from their global locations into a project, and inspect what they hold.",
 }

--- a/commands.yaml
+++ b/commands.yaml
@@ -5,14 +5,17 @@ aliases:
     - ws
 commands:
     - name: ws-cli clip
+      since: 0.2.0
       synopsis: Interact with the native clipboard
       description: Reach the browser clipboard from the terminal over the workspace IPC socket.
       commands:
         - name: ws-cli clip paste
+          since: 0.2.0
           synopsis: Paste clipboard content
           description: Read the browser clipboard over the workspace IPC socket and write it to stdout — redirect it to a file or pipe it onward. Pairs with the pbcopy/xclip/xsel shims for terminal clipboard access.
           usage: ws-cli clip paste
     - name: ws-cli editor
+      since: next
       synopsis: Inspect and drive the active editor session
       description: Query and control the running VS Code / code-server window over the workspace IPC socket — list open tabs, read diagnostics and the current selection, or open a file. Blocked over SSH, where there is no browser editor to reach.
       options:
@@ -21,6 +24,7 @@ commands:
           usage: Output the raw JSON response without styling
       commands:
         - name: ws-cli editor diagnostics
+          since: next
           synopsis: Show language diagnostics for the workspace (or a single file)
           description: Pull language-server diagnostics (errors, warnings) from the editor over the IPC socket, across the whole workspace or a single file with --uri. Styled table by default, --raw for the JSON.
           usage: ws-cli editor diagnostics [flags]
@@ -28,10 +32,12 @@ commands:
             - name: uri
               usage: Filter to a single file (URI or absolute path)
         - name: ws-cli editor list
+          since: next
           synopsis: List the currently open editor tabs
           description: List the editor's open tabs over the IPC socket, with each tab's path, language, and active or dirty state.
           usage: ws-cli editor list
         - name: ws-cli editor open
+          since: next
           synopsis: Open a file in the editor
           description: Open a file in the running editor window over the workspace IPC socket — a tab in the current window by default, a separate one with --new-window, jumping to a range with --selection. Fails fast over SSH, where there is no browser editor to open into.
           usage: ws-cli editor open <file> [flags]
@@ -48,10 +54,12 @@ commands:
             - name: selection
               usage: 'Select a range: LINE:COL[-LINE:COL] (1-based)'
         - name: ws-cli editor selection
+          since: next
           synopsis: Show the active editor's current selection
           description: Report the active editor's current selection — file, range, and selected text — over the IPC socket. Empty when nothing is selected.
           usage: ws-cli editor selection
     - name: ws-cli feature
+      since: 0.2.0
       synopsis: Install additional pre-configured features
       description: Install and inspect optional workspace features — Ansible playbooks that add tools on top of the base image. Ships a curated set; --root points at your own under ~/.ws/features.d.
       options:
@@ -59,10 +67,12 @@ commands:
           usage: Root directory of additional features
       commands:
         - name: ws-cli feature info
+          since: 0.2.0
           synopsis: Show detailed information about a feature
           description: Show a feature's description and the variables it accepts, so you know what --opt values install will take.
           usage: ws-cli feature info <name>
         - name: ws-cli feature install
+          since: 0.2.0
           synopsis: Install additional pre-configured features
           description: Run a feature's playbook to install it. Pass variables with --opt KEY=VAL, and skip parts you do not want with --skip-extensions, --skip-completion, or --skip-repository.
           usage: ws-cli feature install [flags]
@@ -80,12 +90,14 @@ commands:
               default: "false"
               usage: Skip enabling the vendor APT repository
         - name: ws-cli feature list
+          since: 0.2.0
           synopsis: List available features that can be installed
           description: List the features you can install, marking where each comes from — the shipped set, a workspace override, or your own ~/.ws/features.d.
           usage: ws-cli feature list
           aliases:
             - ls
         - name: ws-cli feature new
+          since: 0.2.0
           synopsis: Print boilerplate for a custom feature playbook
           description: |-
             Print a starter feature playbook to stdout.
@@ -96,22 +108,27 @@ commands:
               ws-cli feature new redis > ~/.ws/features.d/redis.yaml
           usage: ws-cli feature new [name]
         - name: ws-cli feature store
+          since: 0.2.0
           synopsis: List packages available in the feature store
           description: List the artifacts published to the feature store (WS_FEATURES_STORE_URL) — the offline mirror features install from when the network is locked down.
           usage: ws-cli feature store
     - name: ws-cli info
+      since: 0.2.0
       synopsis: Display workspace information
       description: Report facts about the running workspace — version, effective environment, installed extensions, live resource metrics, and uptime.
       commands:
         - name: ws-cli info env
+          since: 0.2.0
           synopsis: Display effective workspace environment variables
           description: Print every WS_* variable in effect, sorted — the resolved environment the workspace booted with.
           usage: ws-cli info env
         - name: ws-cli info extensions
+          since: 0.2.0
           synopsis: Display installed extensions
           description: List the installed VS Code extensions with their versions.
           usage: ws-cli info extensions
         - name: ws-cli info metrics
+          since: 0.2.0
           synopsis: Display workspace metrics
           description: Show live resource usage — CPU, memory, disk, and file descriptors, plus GPU with --gpu.
           usage: ws-cli info metrics [flags]
@@ -120,10 +137,12 @@ commands:
               default: "false"
               usage: Include GPU metrics
         - name: ws-cli info uptime
+          since: 0.2.0
           synopsis: Display the workspace uptime
           description: Show when the workspace session started and how long it has been running.
           usage: ws-cli info uptime
         - name: ws-cli info version
+          since: 0.2.0
           synopsis: Display installed workspace version
           description: Print the workspace version. --all expands to the full table — workspace, ws-cli, and VS Code.
           usage: ws-cli info version [flags]
@@ -132,6 +151,7 @@ commands:
               default: "false"
               usage: Show all version information
     - name: ws-cli log
+      since: 0.2.0
       synopsis: Log messages
       description: Emit styled, level-tagged log lines — the same formatting the startup scripts use. --pipe runs each line of piped input through the logger.
       options:
@@ -141,6 +161,7 @@ commands:
           usage: Loop through piped output
       commands:
         - name: ws-cli log debug
+          since: 0.2.0
           synopsis: Log debugging messages
           description: Emit a log line at debug level in the workspace style — the same formatting the startup scripts use. --indent nests it under a preceding line, --stamp prefixes a timestamp.
           usage: ws-cli log debug message [flags]
@@ -154,6 +175,7 @@ commands:
               default: "false"
               usage: Prefix message with current timestamp
         - name: ws-cli log error
+          since: 0.2.0
           synopsis: Log error messages
           description: Emit a log line at error level in the workspace style — the same formatting the startup scripts use. --indent nests it under a preceding line, --stamp prefixes a timestamp.
           usage: ws-cli log error message [flags]
@@ -167,6 +189,7 @@ commands:
               default: "false"
               usage: Prefix message with current timestamp
         - name: ws-cli log info
+          since: 0.2.0
           synopsis: Log information messages
           description: Emit a log line at info level in the workspace style — the same formatting the startup scripts use. --indent nests it under a preceding line, --stamp prefixes a timestamp.
           usage: ws-cli log info message [flags]
@@ -180,10 +203,12 @@ commands:
               default: "false"
               usage: Prefix message with current timestamp
         - name: ws-cli log stamp
+          since: 0.2.0
           synopsis: Log the current timestamp
           description: Print just the current timestamp in the workspace log style — handy for marking phases in a startup log.
           usage: ws-cli log stamp
         - name: ws-cli log warn
+          since: 0.2.0
           synopsis: Log warning messages
           description: Emit a log line at warn level in the workspace style — the same formatting the startup scripts use. --indent nests it under a preceding line, --stamp prefixes a timestamp.
           usage: ws-cli log warn message [flags]
@@ -197,6 +222,7 @@ commands:
               default: "false"
               usage: Prefix message with current timestamp
     - name: ws-cli logs
+      since: 0.2.0
       synopsis: Retrieve workspace logs
       description: Read a workspace daemon's log — the main log by default, or --target metrics|docker|auth_proxy|cloudflared. Filter by --level, limit with --tail, or stream live with --follow.
       usage: ws-cli logs [flags]
@@ -216,6 +242,7 @@ commands:
           default: main
           usage: Log target to read (main|metrics|docker|auth_proxy|cloudflared)
     - name: ws-cli secrets
+      since: 0.2.0
       synopsis: Manage encryption and decryption of secrets
       description: 'Encrypt and decrypt values under a master key, and generate the keys themselves. Encrypted values are what the seed engine''s secrets: map stores and decrypts at boot.'
       options:
@@ -233,22 +260,27 @@ commands:
           usage: Output without styling
       commands:
         - name: ws-cli secrets decrypt
+          since: 0.2.0
           synopsis: Decrypt an encrypted value
           description: Decrypt a value produced by encrypt, under the master key. Reads from the argument or stdin (-); writes the plaintext to stdout, or a file with --output.
           usage: ws-cli secrets decrypt <encrypted|->
         - name: ws-cli secrets encrypt
+          since: 0.2.0
           synopsis: Encrypt a plaintext value
           description: Encrypt a value under the master key. Reads the plaintext from the argument or stdin (-); writes the ciphertext to stdout, or a file with --output.
           usage: ws-cli secrets encrypt <plaintext|->
         - name: ws-cli secrets generate
+          since: 0.2.0
           synopsis: Generate master keys or login password hashes
           description: Generate the credentials the workspace needs — a master key for secrets, or a login password hash for the server.
           commands:
             - name: ws-cli secrets generate login
+              since: 0.2.0
               synopsis: Generate a workspace password hash for authentication
               description: Prompt for a password and print its hash for the workspace server login (WS_AUTH_PASSWORD_HASHED). Store the hash, never the password.
               usage: ws-cli secrets generate login
             - name: ws-cli secrets generate master
+              since: 0.2.0
               synopsis: Generate a cryptographically secure master key
               description: Generate a random master key, printed base64-encoded — the key encrypt, decrypt, and the seed engine use. --length sets the byte size (default 32).
               usage: ws-cli secrets generate master [flags]
@@ -257,6 +289,7 @@ commands:
                   default: "32"
                   usage: Key length in bytes
     - name: ws-cli seed
+      since: next
       synopsis: Project declarative content onto the filesystem
       description: Copy files and apply small edits from a seed source onto the filesystem at boot. Bare files mirror verbatim; a .seed.yaml manifest overlays behavior — copy, merge, append — and decrypts secrets under the master key. Point --source at a mounted volume to seed a container from durable storage.
       options:
@@ -264,6 +297,7 @@ commands:
           usage: Seed source directory
       commands:
         - name: ws-cli seed apply
+          since: next
           synopsis: Project seed content onto the filesystem
           description: Apply the seed source to the filesystem — mirror bare files and run the .seed.yaml operations. Writes only where the destination is missing unless --force; pass destinations to limit the run to those paths.
           usage: ws-cli seed apply [dest...] [flags]
@@ -274,10 +308,12 @@ commands:
             - name: master
               usage: Master key or path to key file
         - name: ws-cli seed ls
+          since: next
           synopsis: List seed destinations and their behaviors
           description: List what apply would write — each destination with its operation and whether it carries a secret or a template — without touching the filesystem.
           usage: ws-cli seed ls
         - name: ws-cli seed rotate
+          since: next
           synopsis: Re-encrypt managed secrets under a new master key
           description: 'Re-encrypt every managed secret from the old master key (--master) to a new one (--new-master), in place. All-or-nothing: it verifies every secret decrypts before writing anything.'
           usage: ws-cli seed rotate [flags]
@@ -287,6 +323,7 @@ commands:
             - name: new-master
               usage: New master key or path to key file
     - name: ws-cli serve
+      since: 0.2.0
       synopsis: Serve internal assets
       description: Run a small HTTP server for local assets — fonts or the current directory — on --port (default 38080).
       options:
@@ -299,22 +336,27 @@ commands:
           usage: Port to serve assets on
       commands:
         - name: ws-cli serve current
+          since: 0.2.0
           synopsis: Serve current directory as a static site
           description: Serve the current directory over HTTP as a static site — a quick way to preview built files.
           usage: ws-cli serve current
         - name: ws-cli serve current
+          since: 0.2.0
           synopsis: Serve current directory as a static site
           description: Serve the current directory over HTTP as a static site — a quick way to preview built files.
           usage: ws-cli serve current [flags]
         - name: ws-cli serve font
+          since: 0.2.0
           synopsis: Serve fonts for local download
           description: Serve the installed fonts over HTTP so a browser can fetch them for local install.
           usage: ws-cli serve font
         - name: ws-cli serve font
+          since: 0.2.0
           synopsis: Serve fonts for local download
           description: Serve the installed fonts over HTTP so a browser can fetch them for local install.
           usage: ws-cli serve font [flags]
         - name: ws-cli serve metrics
+          since: 0.2.0
           synopsis: Start the Prometheus metrics server
           usage: ws-cli serve metrics [flags]
           options:
@@ -326,6 +368,7 @@ commands:
               default: "9100"
               usage: Port to serve metrics on
     - name: ws-cli show
+      since: 0.2.0
       synopsis: Display information about the current workspace instance
       description: Resolve and print facts about this workspace instance — settings, IP addresses, and paths. --raw drops the styling for use in scripts.
       options:
@@ -334,6 +377,7 @@ commands:
           usage: Output raw value without styling
       commands:
         - name: ws-cli show env
+          since: 0.2.0
           synopsis: Display the resolved value of a workspace environment variable
           description: Resolve a setting by its dotted key (server.port) and print it with its source and description. --value emits just the value for scripts, --as bool|int|list validates the shape, --check tests whether it is set so a startup script can guard on it.
           usage: ws-cli show env <KEY> [flags]
@@ -356,26 +400,32 @@ commands:
               default: "false"
               usage: Emit the raw resolved value as a single line
         - name: ws-cli show ip
+          since: 0.2.0
           synopsis: Display IP addresses
           description: Print the workspace's IP addresses — the internal container address or the node it runs on.
           commands:
             - name: ws-cli show ip internal
+              since: 0.2.0
               synopsis: Display the internal IP address
               description: Print the workspace container's internal IP address.
               usage: ws-cli show ip internal
             - name: ws-cli show ip node
+              since: 0.2.0
               synopsis: Display the node/host IP address
               description: Print the IP address of the node hosting the workspace.
               usage: ws-cli show ip node
         - name: ws-cli show path
+          since: 0.2.0
           synopsis: Display various paths
           description: Print well-known workspace paths — the home root or the VS Code settings file.
           commands:
             - name: ws-cli show path home
+              since: 0.2.0
               synopsis: Display the workspace home path
               description: Print the workspace home (server root) path.
               usage: ws-cli show path home
             - name: ws-cli show path vscode-settings
+              since: 0.2.0
               synopsis: Display the VS Code settings path
               description: Print the path to the VS Code settings file — the user file by default, or the folder's with --workspace.
               usage: ws-cli show path vscode-settings [flags]
@@ -384,10 +434,12 @@ commands:
                   default: "false"
                   usage: Get the workspace settings
     - name: ws-cli template
+      since: 0.2.0
       synopsis: Manage static configuration files
       description: Copy shared configuration files (linters, formatters) from their global locations into a project, and inspect what they hold.
       commands:
         - name: ws-cli template apply
+          since: 0.2.0
           synopsis: Apply a configuration template to the current project
           description: Copy a template into the project — a shared config like ruff or markdownlint — to --path (the current directory by default). --force overwrites an existing file.
           usage: ws-cli template apply <template> [flags]
@@ -400,12 +452,14 @@ commands:
               default: .
               usage: Target directory path
         - name: ws-cli template list
+          since: 0.2.0
           synopsis: List all available configuration templates
           description: List the templates you can apply, with their source paths and whether one is already applied here.
           usage: ws-cli template list
           aliases:
             - ls
         - name: ws-cli template show
+          since: 0.2.0
           synopsis: Display the contents of a configuration template
           description: |-
             Display the contents of a configuration template.

--- a/internals/docs/serialize.go
+++ b/internals/docs/serialize.go
@@ -18,6 +18,8 @@ type Option struct {
 
 type Command struct {
 	Name        string    `yaml:"name"`
+	Since       string    `yaml:"since,omitempty"`
+	Deprecated  string    `yaml:"deprecated,omitempty"`
 	Synopsis    string    `yaml:"synopsis,omitempty"`
 	Description string    `yaml:"description,omitempty"`
 	Usage       string    `yaml:"usage,omitempty"`
@@ -34,10 +36,16 @@ func Serialize(root *cobra.Command) ([]byte, error) {
 func walk(c *cobra.Command) Command {
 	command := Command{
 		Name:        c.CommandPath(),
+		Since:       c.Annotations["since"],
+		Deprecated:  c.Annotations["deprecated"],
 		Synopsis:    c.Short,
 		Description: c.Long,
 		Aliases:     c.Aliases,
 		Example:     c.Example,
+	}
+
+	if command.Deprecated != "" {
+		command.Since = ""
 	}
 
 	if c.Runnable() {

--- a/internals/docs/serialize_test.go
+++ b/internals/docs/serialize_test.go
@@ -24,6 +24,61 @@ func TestSerializeOmitsAbsolutePathDefaults(t *testing.T) {
 	assert.Assert(t, strings.Contains(rendered, "default: \"38080\""))
 }
 
+func TestSerializeEmitsSinceAnnotation(t *testing.T) {
+	root := &cobra.Command{Use: "demo"}
+	root.AddCommand(&cobra.Command{
+		Use:         "tagged",
+		Annotations: map[string]string{"since": "0.4.1"},
+		Run:         func(*cobra.Command, []string) {},
+	})
+	root.AddCommand(&cobra.Command{Use: "plain", Run: func(*cobra.Command, []string) {}})
+
+	out, err := Serialize(root)
+	assert.NilError(t, err)
+
+	rendered := string(out)
+	assert.Assert(t, strings.Contains(rendered, "since: 0.4.1"),
+		"since annotation must be emitted:\n%s", rendered)
+	assert.Equal(t, strings.Count(rendered, "since:"), 1,
+		"unannotated commands must omit since:\n%s", rendered)
+}
+
+func TestSerializeEmitsDeprecatedAnnotation(t *testing.T) {
+	root := &cobra.Command{Use: "demo"}
+	root.AddCommand(&cobra.Command{
+		Use:         "tagged",
+		Annotations: map[string]string{"deprecated": "0.5.0"},
+		Run:         func(*cobra.Command, []string) {},
+	})
+	root.AddCommand(&cobra.Command{Use: "plain", Run: func(*cobra.Command, []string) {}})
+
+	out, err := Serialize(root)
+	assert.NilError(t, err)
+
+	rendered := string(out)
+	assert.Assert(t, strings.Contains(rendered, "deprecated: 0.5.0"),
+		"deprecated annotation must be emitted:\n%s", rendered)
+	assert.Equal(t, strings.Count(rendered, "deprecated:"), 1,
+		"unannotated commands must omit deprecated:\n%s", rendered)
+}
+
+func TestSerializeDeprecatedSupersedesSince(t *testing.T) {
+	root := &cobra.Command{
+		Use:         "demo",
+		Annotations: map[string]string{"since": "0.2.0", "deprecated": "0.5.0"},
+		Run:         func(*cobra.Command, []string) {},
+	}
+
+	out, err := Serialize(root)
+	assert.NilError(t, err)
+
+	rendered := string(out)
+	assert.Assert(t, strings.Contains(rendered, "deprecated: 0.5.0"),
+		"deprecated annotation must be emitted:\n%s", rendered)
+	assert.Assert(t, !strings.Contains(rendered, "since:"),
+		"a deprecated command must drop since:\n%s", rendered)
+}
+
 func TestSerializeSortsChildrenAndOmitsHidden(t *testing.T) {
 	root := &cobra.Command{Use: "demo"}
 	root.AddCommand(&cobra.Command{Use: "zebra", Run: func(*cobra.Command, []string) {}})


### PR DESCRIPTION
Bring `ws-cli` commands to per-item version-annotation parity with env vars, so the ws-docs command reference renders "Since v…" / "Deprecated v…" badges per command — now that ws-cli is versionless (q3-2) and commands are versioned by the **workspace** release.

## Changes
- **`internals/docs/serialize.go`** — add a `Deprecated` field beside `Since` (both from cobra `Annotations`, `omitempty`); blank `Since` when `Deprecated` is set so `commands.yaml` carries a single version marker (deprecated supersedes since at the data level).
- **`cmd/**/*.go`** — backfill a `since` annotation on every command (no cobra inheritance, leaves included): released groups floor to `0.2.0`; the unreleased **seed** and **editor** groups use `next`, which the workspace release codemod resolves to the cut version.
- **`commands.yaml`** — regenerated via `tools/gen-commands`.
- **Tests** — serialize `since`/`deprecated`/supersede matrix; `TestEveryCommandCarriesVersion` guard (every command carries `since` or `deprecated`, walked over the emitted tree) so a future command added without an annotation fails CI.

## Notes
- Additive metadata only — no command names, flags, or `show env --check` surface touched.
- Companion ws-docs render change (deprecated badge in `generate-commands.mjs`) lands separately; the badge is dormant until a real deprecation + distribution.